### PR TITLE
Use newtype pattern for input validation

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,13 +1,13 @@
 pub type BngResult<T> = std::result::Result<T, BngError>;
 
 pub enum BngError {
-    Badness(),
+    InvalidReferenceString(String),
 }
 
 impl std::fmt::Display for BngError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            BngError::Badness() => write!(f, "Not so good..."),
+            BngError::InvalidReferenceString(string) => write!(f, "{}", string),
         }
     }
 }
@@ -15,7 +15,7 @@ impl std::fmt::Display for BngError {
 impl std::fmt::Debug for BngError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Badness() => f.debug_tuple("Badness").finish(),
+            Self::InvalidReferenceString(string) => f.debug_tuple(string).finish(),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,8 @@
-use geo_types::Coordinate;
-use national_grid::Reference;
+use national_grid::reference_string::ReferenceString;
+use std::str::FromStr;
 
 fn main() -> anyhow::Result<()> {
-    let coordinate = Coordinate {
-        x: 100_000,
-        y: 500_000,
-    };
-    let reference = Reference::try_from(coordinate)?;
-    println!("{:?}", reference);
+    let reference_string = ReferenceString::from_str("AB01234567891")?;
+    println!("{:?}", reference_string);
     Ok(())
 }

--- a/src/reference_string.rs
+++ b/src/reference_string.rs
@@ -1,0 +1,39 @@
+use crate::error::{BngError, BngResult};
+use regex::Regex;
+use std::str::FromStr;
+
+#[derive(Debug)]
+pub struct ReferenceString(String);
+
+impl ReferenceString {
+    pub fn value(&self) -> &str {
+        &self.0
+    }
+}
+
+impl FromStr for ReferenceString {
+    type Err = BngError;
+
+    fn from_str(s: &str) -> BngResult<ReferenceString> {
+        let upper = s.to_uppercase();
+        let re = Regex::new(r"^[HJNOSW][^I](\d\d){0,5}$").unwrap();
+        if re.is_match(&upper) {
+            Ok(ReferenceString { 0: upper })
+        } else {
+            match upper {
+                upper if upper.len() == 1 => {
+                    Err(BngError::InvalidReferenceString("Too short".to_string()))
+                }
+                upper if upper.len() > 12 => {
+                    Err(BngError::InvalidReferenceString("Too long".to_string()))
+                }
+                upper if upper.len() % 2 != 0 => {
+                    Err(BngError::InvalidReferenceString("Odd".to_string()))
+                }
+                _ => Err(BngError::InvalidReferenceString(
+                    "Something else".to_string(),
+                )),
+            }
+        }
+    }
+}


### PR DESCRIPTION
Many thanks for your suggestions, I'd been struggling to get `thiserror` to work by myself!

The main idea here is to move all the validation to the conversion from `&str` to `ReferenceString` so that the conversion from `ReferenceString` to `Reference` cannot fail. I'm planning to do something for similar for the conversion from `Coordinate`. 